### PR TITLE
Fix typos and spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ class ArticlesController < ApplicationController
   end
 end
 ```
-Assuming your routes and views are setup, you should be able to succesfully visit `/articles`.
+Assuming your routes and views are setup, you should be able to successfully visit `/articles`.
 
 You can annotate this action with a promise of how many database queries the action will make so:
 ```ruby
@@ -144,7 +144,7 @@ And now, we've successfully caught and averted a bad code commit!
 By default, `performance_promise` runs only in `development` and `testing`. This ensures that you can identify issues when developing or running your test-suite. Be very careful about enabling this in `production` – you almost certainly don't want to.
 
 #### `throw_exception: bool`
-Tells `performance_promise` whether to throw an exception. Set to `true` by default, but can be overriden if you simply want to ignore failing cases (they will still be written to the log).
+Tells `performance_promise` whether to throw an exception. Set to `true` by default, but can be overridden if you simply want to ignore failing cases (they will still be written to the log).
 
 #### `speedy_promise: hash`
 If you do not care to determine the _exact_ performance of your action, you can still simply mark it as `Speedy`:
@@ -157,7 +157,7 @@ If you do not care to determine the _exact_ performance of your action, you can 
 A `Speedy` action is supposed to be well behaved, making lesser than `x` database queries, and taking less than `y` to complete. You can set these defaults using this configuration parameter.
 
 #### `untagged_methods_are_speedy: bool`
-By default, actions that are not annotated aren't validated by `performance_promise`. If you'd like to force all actions to be validated, one option is to simply default them all to be `Speedy`. This allows developers to make _no_ change to their code, while still reaping the benefits of performance validation. Iff a view fails to be `Speedy`, then the developer is forced to acknowledge it in code.
+By default, actions that are not annotated aren't validated by `performance_promise`. If you'd like to force all actions to be validated, one option is to simply default them all to be `Speedy`. This allows developers to make _no_ change to their code, while still reaping the benefits of performance validation. If a view fails to be `Speedy`, then the developer is forced to acknowledge it in code.
 
 
 ## FAQ
@@ -165,11 +165,11 @@ By default, actions that are not annotated aren't validated by `performance_prom
 
 We borrow the coding style from Python's `decorators`. This style allows for a function to be wrapped by another. This is a great use case for that style since it allows for us to express the annotation right above the function definition.
 
-Credit goes to [Yehuda Katz][yehuda-katz] for the [port of decortators][ruby-decorators] into Ruby.
+Credit goes to [Yehuda Katz][yehuda-katz] for the [port of decorators][ruby-decorators] into Ruby.
 
 > **Will this affect my production service?**
 
-By default, `performace_promise` is applied only in `development` and `test` environments. You can choose to override this, but is strongly discouraged.
+By default, `performance_promise` is applied only in `development` and `test` environments. You can choose to override this, but is strongly discouraged.
 
 
 > **What are some other kinds of performance guarantees that I can make with `performance_promise`?**
@@ -192,7 +192,7 @@ If you come up with other validations that you think will be useful, please cons
 
 `performance_promise` can be tuned to not only identify N + 1 queries, but can also alert whenever there's _any_ change in performance.  It allows you to identify expensive actions irrespective of their database query profile.
 
-`performance_promise` also has access to the entire database query object. In the future, `performance_promise` can be tuned to perform additonal checks like how long the most expensive query took, whether the action performed any table scans (available through an `EXPLAIN`) etc.
+`performance_promise` also has access to the entire database query object. In the future, `performance_promise` can be tuned to perform additional checks like how long the most expensive query took, whether the action performed any table scans (available through an `EXPLAIN`) etc.
 
 Finally, the difference between `bullet` and `performance_promise` is akin to testing by refreshing your browser and testing by writing specs. `performance_promise` encourages you to specify your action's performance by declaring it in code itself. This allows both  code-reviewers as well as automated tests to verify your code's performance.
 


### PR DESCRIPTION
Just some things I noticed while reading the documentation.
